### PR TITLE
Adding maxBuffer to child process

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -40,7 +40,7 @@ function createFontFile(fontJson, callback) {
 
 			// I tried lots of things to buffer the binary input, and encode to base64 within node.
 			// None of them came out as valid font-files, so I'm falling back to what I run on the CLI, which works (on my machine!)
-			exec("openssl base64 < " + font.file + " | tr -d '\n'", function(error, stdout, stderr) {
+			exec("openssl base64 < " + font.file + " | tr -d '\n'", {env: process.env, maxBuffer: 20*1024*1024}, function(error, stdout, stderr) {
 				if (!error && !stderr && stdout) {
 					font.base64 = stdout;
 


### PR DESCRIPTION
Was encountering "[Error: stdout maxBuffer exceeded.]" encoding large fonts.
